### PR TITLE
restore grid LED mapping on script clear

### DIFF
--- a/metrix.lua
+++ b/metrix.lua
@@ -22,6 +22,13 @@ function grid:led(x, y, val)
     _norns.grid_set_led(self.dev, y, 9 - x, val)
 end
 
+-- restore default rotation on script clear
+function cleanup()
+  function grid:led(x, y, val)
+    _norns.grid_set_led(self.dev, x, y, val)
+  end
+end
+
 g = grid.connect()
 
 -- molly the poly


### PR DESCRIPTION
the `manual grid rotation` method employed overwrites core norns functionality beyond the scope of the script, so this leaves a grid in this modified state after the script is cleared. this PR adds a `cleanup` function, which norns calls whenever a script is cleared / switched, which restores the LED handling to its original state :)